### PR TITLE
Replace const with var

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 module.exports = function circularAt (array, index) {
-  const length = array && array.length
+  var length = array && array.length
   var idx = Math.abs(length + index % length) % length
   return array[isNaN(idx) ? index : idx]
 }


### PR DESCRIPTION
This module was used in a browser project, and because of the `const` was failing to uglify.
Figured this would be a non-controversial change.